### PR TITLE
Add CONFIG_PATH env var

### DIFF
--- a/odd_collector_aws/__main__.py
+++ b/odd_collector_aws/__main__.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         loop = asyncio.get_event_loop()
 
         cur_dirname = path.dirname(path.realpath(__file__))
-        config_path = path.join(cur_dirname, "../collector_config.yaml")
+        config_path = os.getenv("CONFIG_PATH", path.join(cur_dirname, "../collector_config.yaml"))
         root_package = "odd_collector_aws.adapters"
 
         collector = Collector(config_path, root_package, PLUGIN_FACTORY)


### PR DESCRIPTION
Will close #19
If env var `CONFIG_PATH` is not defined the system will continue to use the default file location (`collector_config.yaml` file from the parent folder), in another case, the system be initialized with a configuration path from env var